### PR TITLE
Add standalone Taxtweb

### DIFF
--- a/openquakeplatform_server/settings.py
+++ b/openquakeplatform_server/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = (
 
     'openquakeplatform_standalone',
     'openquakeplatform_ipt',
+    'openquakeplatform_taxtweb',
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (

--- a/openquakeplatform_server/urls.py
+++ b/openquakeplatform_server/urls.py
@@ -27,4 +27,5 @@ urlpatterns = patterns('',
 
     url(r'^admin/', include(admin.site.urls)),
     url(r'^ipt/', include("openquakeplatform_ipt.urls"), name='home'),
+    url(r'^taxtweb/', include("openquakeplatform_taxtweb.urls"), name='taxtweb'),
 )


### PR DESCRIPTION
The standalone version has been added to the new repo: https://github.com/gem/oq-platform-taxtweb

This is the companion of https://github.com/gem/oq-platform/pull/597
