### PR TITLE
Allowed hosts fix

### DIFF
--- a/openquakeplatform_server/settings.py
+++ b/openquakeplatform_server/settings.py
@@ -27,7 +27,7 @@ DEBUG = True
 
 TEMPLATE_DEBUG = True
 
-ALLOWED_HOSTS = ["HERE_ALLOWED_HOST" ]
+ALLOWED_HOSTS = ["localhost", "127.0.0.1" ]
 
 # Application definition
 

--- a/verifier.sh
+++ b/verifier.sh
@@ -485,9 +485,13 @@ devtest_run () {
     local deps old_ifs branch_id="$1"
 
     sudo echo
-    sudo ${GEM_EPHEM_EXE} 2>&1 | tee /tmp/packager.eph.$$.log &
-    _lxc_name_and_ip_get /tmp/packager.eph.$$.log
-    rm /tmp/packager.eph.$$.log
+    if [ "$GEM_EPHEM_EXE" == "$GEM_EPHEM_NAME" ]; then
+        _lxc_name_and_ip_get
+    else
+        sudo ${GEM_EPHEM_EXE} 2>&1 | tee /tmp/packager.eph.$$.log &
+        _lxc_name_and_ip_get /tmp/packager.eph.$$.log
+        rm /tmp/packager.eph.$$.log
+    fi
 
     _wait_ssh $lxc_ip
     set +e
@@ -609,9 +613,13 @@ prodtest_run () {
     local deps old_ifs branch_id="$1"
 
     sudo echo
-    sudo ${GEM_EPHEM_EXE} 2>&1 | tee /tmp/packager.eph.$$.log &
-    _lxc_name_and_ip_get /tmp/packager.eph.$$.log
-    rm /tmp/packager.eph.$$.log
+    if [ "$GEM_EPHEM_EXE" == "$GEM_EPHEM_NAME" ]; then
+        _lxc_name_and_ip_get
+    else
+        sudo ${GEM_EPHEM_EXE} 2>&1 | tee /tmp/packager.eph.$$.log &
+        _lxc_name_and_ip_get /tmp/packager.eph.$$.log
+        rm /tmp/packager.eph.$$.log
+    fi
 
     _wait_ssh $lxc_ip
     set +e

--- a/verifier.sh
+++ b/verifier.sh
@@ -485,7 +485,7 @@ devtest_run () {
     local deps old_ifs branch_id="$1"
 
     sudo echo
-    if [ "$GEM_EPHEM_EXE" == "$GEM_EPHEM_NAME" ]; then
+    if [ "$GEM_EPHEM_EXE" = "$GEM_EPHEM_NAME" ]; then
         _lxc_name_and_ip_get
     else
         sudo ${GEM_EPHEM_EXE} 2>&1 | tee /tmp/packager.eph.$$.log &
@@ -613,7 +613,7 @@ prodtest_run () {
     local deps old_ifs branch_id="$1"
 
     sudo echo
-    if [ "$GEM_EPHEM_EXE" == "$GEM_EPHEM_NAME" ]; then
+    if [ "$GEM_EPHEM_EXE" = "$GEM_EPHEM_NAME" ]; then
         _lxc_name_and_ip_get
     else
         sudo ${GEM_EPHEM_EXE} 2>&1 | tee /tmp/packager.eph.$$.log &


### PR DESCRIPTION
With this PR we fix a problem arising from increased strictness from new python-django ubuntu package.
Included in this PR:
  * lxc refactoring to abandon legacy pre 2.0 versions of lxc
  * possibility to use, instead of a ephemeral lxc an already running permanent lxc exporting before a set of environment variables like:
    ```bash
    export GEM_EPHEM_NAME='<lxc-machine-name>'
    export GEM_EPHEM_DESTROY='echo Not destroy'
    export GEM_EPHEM_EXE='<lxc-machine-name>'
    ```
Tests are green here: https://ci.openquake.org/job/zdevel_oq-platform-standalone/42/console