### PR TITLE
Allowed hosts fix, lxc refactoring, permanent lxc option

### DIFF
--- a/openquakeplatform_server/settings.py
+++ b/openquakeplatform_server/settings.py
@@ -27,7 +27,7 @@ DEBUG = True
 
 TEMPLATE_DEBUG = True
 
-ALLOWED_HOSTS = ["HERE_ALLOWED_HOST" ]
+ALLOWED_HOSTS = ["localhost", "127.0.0.1" ]
 
 # Application definition
 

--- a/verifier.sh
+++ b/verifier.sh
@@ -216,7 +216,6 @@ sig_hand () {
         if [ "$LXC_DESTROY" = "lxc-destroy" ]; then
             sudo $LXC_KILL -n $lxc_name
         fi
-        sudo $LXC_DESTROY -n $lxc_name
     fi
     if [ -f /tmp/packager.eph.$$.log ]; then
         rm /tmp/packager.eph.$$.log

--- a/verifier.sh
+++ b/verifier.sh
@@ -95,7 +95,7 @@ LXC_TERM="lxc-stop -t 10"
 LXC_KILL="lxc-stop -k"
 
 if [ "$GEM_EPHEM_EXE" != "" ]; then
-    echo "Use [$GEM_EPHEM_EXE] to run lxc"
+    echo "Using [$GEM_EPHEM_EXE] to run lxc"
 else
     GEM_EPHEM_EXE="lxc-copy -n ${GEM_EPHEM_NAME} -e"
 fi

--- a/verifier.sh
+++ b/verifier.sh
@@ -41,7 +41,7 @@
 #
 # - exports:
 # export GEM_EPHEM_NAME='<lxc-machine-name>'
-# export GEM_EPHEM_DESTROY='echo Not destroy'
+# export GEM_EPHEM_DESTROY='false'
 # export GEM_EPHEM_EXE='<lxc-machine-name>'
 #
 # run ./verifier.sh prodtest <your-branch-name>
@@ -103,7 +103,7 @@ fi
 if [ "$GEM_EPHEM_DESTROY" != "" ]; then
     LXC_DESTROY="$GEM_EPHEM_DESTROY"
 else
-    LXC_DESTROY="lxc-destroy"
+    LXC_DESTROY="true"
 fi
 
 ACTION="none"
@@ -213,7 +213,7 @@ sig_hand () {
             fi"
 
         echo "Destroying [$lxc_name] lxc"
-        if [ "$LXC_DESTROY" = "lxc-destroy" ]; then
+        if [ "$LXC_DESTROY" = "true" ]; then
             sudo $LXC_KILL -n $lxc_name
         fi
     fi
@@ -498,7 +498,7 @@ devtest_run () {
         ssh -t  $lxc_ip "cd ~/$GEM_GIT_PACKAGE; . platform-env/bin/activate ; killall runserver.sh"
     fi
 
-    if [ "$LXC_DESTROY" = "lxc-destroy" ]; then
+    if [ "$LXC_DESTROY" = "true" ]; then
         sudo $LXC_TERM -n $lxc_name
     fi
 
@@ -627,7 +627,7 @@ prodtest_run () {
         :
     fi
 
-    if [ "$LXC_DESTROY" = "lxc-destroy" ]; then
+    if [ "$LXC_DESTROY" = "true" ]; then
         sudo $LXC_TERM -n $lxc_name
     fi
 

--- a/verifier.sh
+++ b/verifier.sh
@@ -37,15 +37,12 @@
 # you can use verifier.sh to install a permanent LXC machine
 #
 # to do it:
+# - create and run a new lxc of the same serie used here
 #
-# - copy openquakeplatform/bin/lxc-* to your /usr/local/sbin
-#
-# - set these env variables (change <lxc-machine-name> with your m. name)
-#
-# export GEM_EPHEM_IP_GET=lxc-ip-get-gem
-# export GEM_EPHEM_NAME=<lxc-machine-name>
-# export GEM_EPHEM_DESTROY=echo lxc-destroy-fake
-# export GEM_EPHEM_CMD=lxc-start-gem
+# - exports:
+# export GEM_EPHEM_NAME='<lxc-machine-name>'
+# export GEM_EPHEM_DESTROY='echo Not destroy'
+# export GEM_EPHEM_EXE='<lxc-machine-name>'
 #
 # run ./verifier.sh prodtest <your-branch-name>
 

--- a/verifier.sh
+++ b/verifier.sh
@@ -485,9 +485,13 @@ devtest_run () {
     local deps old_ifs branch_id="$1"
 
     sudo echo
-    sudo ${GEM_EPHEM_EXE} 2>&1 | tee /tmp/packager.eph.$$.log &
-    _lxc_name_and_ip_get /tmp/packager.eph.$$.log
-    rm /tmp/packager.eph.$$.log
+    if [ "$GEM_EPHEM_EXE" == "$GEM_EPHEM_NAME" ]; then
+        _lxc_name_and_ip_get
+    else
+        sudo ${GEM_EPHEM_EXE} 2>&1 | tee /tmp/packager.eph.$$.log &
+        _lxc_name_and_ip_get /tmp/packager.eph.$$.log
+        rm /tmp/packager.eph.$$.log
+    fi
 
     _wait_ssh $lxc_ip
     set +e
@@ -609,9 +613,13 @@ prodtest_run () {
     local deps old_ifs branch_id="$1"
 
     sudo echo
-    sudo ${GEM_EPHEM_EXE} 2>&1 | tee /tmp/packager.eph.$$.log &
-    _lxc_name_and_ip_get /tmp/packager.eph.$$.log
-    rm /tmp/packager.eph.$$.log
+    if [ "$GEM_EPHEM_EXE" == "$GEM_EPHEM_NAME" ]; then
+        _lxc_name_and_ip_get
+    else
+        sudo ${GEM_EPHEM_EXE} 2>&1 | tee /tmp/packager.eph.$$.log &
+        _lxc_name_and_ip_get /tmp/packager.eph.$$.log
+        rm /tmp/packager.eph.$$.log
+    fi
 
     _wait_ssh $lxc_ip
     set +e

--- a/verifier.sh
+++ b/verifier.sh
@@ -83,9 +83,6 @@ GEM_MAXLOOP=20
 
 GEM_ALWAYS_YES=false
 
-if [ "$GEM_EPHEM_CMD" = "" ]; then
-    GEM_EPHEM_CMD="lxc-start-ephemeral"
-fi
 if [ "$GEM_EPHEM_NAME" = "" ]; then
     GEM_EPHEM_NAME="ubuntu14-x11-lxc-eph"
 fi

--- a/verifier.sh
+++ b/verifier.sh
@@ -485,7 +485,7 @@ devtest_run () {
     local deps old_ifs branch_id="$1"
 
     sudo echo
-    if [ "$GEM_EPHEM_EXE" == "$GEM_EPHEM_NAME" ]; then
+    if [ "$GEM_EPHEM_EXE" = "$GEM_EPHEM_NAME" ]; then
         _lxc_name_and_ip_get
     else
         sudo ${GEM_EPHEM_EXE} 2>&1 | tee /tmp/packager.eph.$$.log &
@@ -613,7 +613,7 @@ prodtest_run () {
     local deps old_ifs branch_id="$1"
 
     sudo echo
-    if [ "$GEM_EPHEM_EXE" == "$GEM_EPHEM_NAME" ]; then
+    if [ "$GEM_EPHEM_EXE" = "$GEM_EPHEM_NAME" ]; then
         _lxc_name_and_ip_get
     else
         sudo ${GEM_EPHEM_EXE} 2>&1 | tee /tmp/packager.eph.$$.log &


### PR DESCRIPTION
With this PR we fix a problem arising from increased strictness from new python-django ubuntu package.
Included in this PR:
  * lxc refactoring to abandon legacy pre 2.0 versions of lxc
  * possibility to use, instead of a ephemeral lxc an already running permanent lxc exporting before a set of environment variables like:
    ```bash
    export GEM_EPHEM_NAME='<lxc-machine-name>'
    export GEM_EPHEM_DESTROY='echo Not destroy'
    export GEM_EPHEM_EXE='<lxc-machine-name>'
    ```
Tests are green here: https://ci.openquake.org/job/zdevel_oq-platform-standalone/42/console
New tests are green here: https://ci.openquake.org/job/zdevel_oq-platform-standalone/43/console