### PR TITLE
Make standalone compatible with Django 1.5 - 1.10

### DIFF
--- a/openquakeplatform/templates/base.html
+++ b/openquakeplatform/templates/base.html
@@ -70,8 +70,7 @@
 
     {% block extra_script %}{% endblock extra_script %}
 
-    <script type="text/javascript" src="{% url "django.views.i18n.javascript_catalog" %}"></script>
-    <script type="text/javascript" src="{% url "lang" %}"></script>
+    <script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
     <style type="text/css">
       .select2-drop{
         color: black;

--- a/openquakeplatform_server/settings.py
+++ b/openquakeplatform_server/settings.py
@@ -32,14 +32,14 @@ if StrictVersion(get_version()) < StrictVersion('1.8'):
     # For backward compatibility with Django < 1.8
     # Be aware that names are different (template -> core)
     TEMPLATE_CONTEXT_PROCESSORS = (
-        'django.contrib.auth.context_processors.auth',
+        # 'django.contrib.auth.context_processors.auth',
+        'django.core.context_processors.request',
         'django.core.context_processors.debug',
         'django.core.context_processors.i18n',
-        'django.core.context_processors.tz',
         'django.core.context_processors.media',
         'django.core.context_processors.static',
-        'django.core.context_processors.request',
-        'django.contrib.messages.context_processors.messages',
+        'django.core.context_processors.tz',
+        # 'django.contrib.messages.context_processors.messages',
         'openquakeplatform.utils.oq_context_processor',
     )
 else:

--- a/openquakeplatform_server/settings.py
+++ b/openquakeplatform_server/settings.py
@@ -8,8 +8,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.6/ref/settings/
 """
 import os
-from django import get_version
-from distutils.version import StrictVersion
+
 
 # Standalone flag to differentiate behaviors
 STANDALONE = True
@@ -28,40 +27,48 @@ ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-if StrictVersion(get_version()) < StrictVersion('1.8'):
-    # For backward compatibility with Django < 1.8
-    # Be aware that names are different (template -> core)
-    TEMPLATE_CONTEXT_PROCESSORS = (
-        # 'django.contrib.auth.context_processors.auth',
-        'django.core.context_processors.request',
-        'django.core.context_processors.debug',
-        'django.core.context_processors.i18n',
-        'django.core.context_processors.media',
-        'django.core.context_processors.static',
-        'django.core.context_processors.tz',
-        # 'django.contrib.messages.context_processors.messages',
-        'openquakeplatform.utils.oq_context_processor',
-    )
-else:
-    TEMPLATES = [
-        {
-            'BACKEND': 'django.template.backends.django.DjangoTemplates',
-            'APP_DIRS': True,
-            'OPTIONS': {
-                'context_processors': [
-                    # 'django.contrib.auth.context_processors.auth',
-                    'django.template.context_processors.request',
-                    'django.template.context_processors.debug',
-                    'django.template.context_processors.i18n',
-                    'django.template.context_processors.media',
-                    'django.template.context_processors.static',
-                    'django.template.context_processors.tz',
-                    # 'django.contrib.messages.context_processors.messages',
-                    'openquakeplatform.utils.oq_context_processor',
-                ],
+# This ugly hack is needed because in verifiers we are importing
+# this file on the host and without Django installed to get INSTALLED_APPS
+try:
+    from django import get_version
+    from distutils.version import StrictVersion
+
+    if StrictVersion(get_version()) < StrictVersion('1.8'):
+        # For backward compatibility with Django < 1.8
+        # Be aware that names are different (template -> core)
+        TEMPLATE_CONTEXT_PROCESSORS = (
+            # 'django.contrib.auth.context_processors.auth',
+            'django.core.context_processors.request',
+            'django.core.context_processors.debug',
+            'django.core.context_processors.i18n',
+            'django.core.context_processors.media',
+            'django.core.context_processors.static',
+            'django.core.context_processors.tz',
+            # 'django.contrib.messages.context_processors.messages',
+            'openquakeplatform.utils.oq_context_processor',
+        )
+    else:
+        TEMPLATES = [
+            {
+                'BACKEND': 'django.template.backends.django.DjangoTemplates',
+                'APP_DIRS': True,
+                'OPTIONS': {
+                    'context_processors': [
+                        # 'django.contrib.auth.context_processors.auth',
+                        'django.template.context_processors.request',
+                        'django.template.context_processors.debug',
+                        'django.template.context_processors.i18n',
+                        'django.template.context_processors.media',
+                        'django.template.context_processors.static',
+                        'django.template.context_processors.tz',
+                        # 'django.contrib.messages.context_processors.messages',
+                        'openquakeplatform.utils.oq_context_processor',
+                    ],
+                },
             },
-        },
-    ]
+        ]
+except ImportError:
+    pass
 
 # Application definition
 INSTALLED_APPS = (

--- a/openquakeplatform_server/settings.py
+++ b/openquakeplatform_server/settings.py
@@ -8,6 +8,8 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.6/ref/settings/
 """
 import os
+from django import get_version
+from distutils.version import StrictVersion
 
 # Standalone flag to differentiate behaviors
 STANDALONE = True
@@ -26,40 +28,40 @@ ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-TEMPLATES = [
-    {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                # 'django.contrib.auth.context_processors.auth',
-                'django.template.context_processors.request',
-                'django.template.context_processors.debug',
-                'django.template.context_processors.i18n',
-                'django.template.context_processors.media',
-                'django.template.context_processors.static',
-                'django.template.context_processors.tz',
-                # 'django.contrib.messages.context_processors.messages',
-                'openquakeplatform.utils.oq_context_processor',
-            ],
+if StrictVersion(get_version()) < StrictVersion('1.8'):
+    # For backward compatibility with Django < 1.8
+    # Be aware that names are different (template -> core)
+    TEMPLATE_CONTEXT_PROCESSORS = (
+        'django.contrib.auth.context_processors.auth',
+        'django.core.context_processors.debug',
+        'django.core.context_processors.i18n',
+        'django.core.context_processors.tz',
+        'django.core.context_processors.media',
+        'django.core.context_processors.static',
+        'django.core.context_processors.request',
+        'django.contrib.messages.context_processors.messages',
+        'openquakeplatform.utils.oq_context_processor',
+    )
+else:
+    TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    # 'django.contrib.auth.context_processors.auth',
+                    'django.template.context_processors.request',
+                    'django.template.context_processors.debug',
+                    'django.template.context_processors.i18n',
+                    'django.template.context_processors.media',
+                    'django.template.context_processors.static',
+                    'django.template.context_processors.tz',
+                    # 'django.contrib.messages.context_processors.messages',
+                    'openquakeplatform.utils.oq_context_processor',
+                ],
+            },
         },
-    },
-]
-
-# For backward compatibility with Django 1.5
-# Be aware that names are different (template -> core)
-
-TEMPLATE_CONTEXT_PROCESSORS = (
-    'django.contrib.auth.context_processors.auth',
-    'django.core.context_processors.debug',
-    'django.core.context_processors.i18n',
-    'django.core.context_processors.tz',
-    'django.core.context_processors.media',
-    'django.core.context_processors.static',
-    'django.core.context_processors.request',
-    'django.contrib.messages.context_processors.messages',
-    'openquakeplatform.utils.oq_context_processor',
-)
+    ]
 
 # Application definition
 INSTALLED_APPS = (

--- a/openquakeplatform_server/settings.py
+++ b/openquakeplatform_server/settings.py
@@ -89,8 +89,8 @@ STANDALONE_APPS = (
 )
 
 MIDDLEWARE_CLASSES = (
+    'django.middleware.common.CommonMiddleware',
     # 'django.contrib.sessions.middleware.SessionMiddleware',
-    # 'django.middleware.common.CommonMiddleware',
     # 'django.middleware.csrf.CsrfViewMiddleware',
     # 'django.contrib.auth.middleware.AuthenticationMiddleware',
     # 'django.contrib.messages.middleware.MessageMiddleware',

--- a/openquakeplatform_server/settings.py
+++ b/openquakeplatform_server/settings.py
@@ -27,7 +27,7 @@ ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-# This ugly hack is needed because in verifiers we are importing
+# This ugly hack is needed because in verifier.sh we are importing
 # this file on the host and without Django installed to get INSTALLED_APPS
 try:
     from django import get_version

--- a/openquakeplatform_server/settings.py
+++ b/openquakeplatform_server/settings.py
@@ -32,8 +32,8 @@ TEMPLATES = [
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
-                'django.core.context_processors.request',
                 # 'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.request',
                 'django.template.context_processors.debug',
                 'django.template.context_processors.i18n',
                 'django.template.context_processors.media',
@@ -45,6 +45,21 @@ TEMPLATES = [
         },
     },
 ]
+
+# For backward compatibility with Django 1.5
+# Be aware that names are different (template -> core)
+
+TEMPLATE_CONTEXT_PROCESSORS = (
+    'django.contrib.auth.context_processors.auth',
+    'django.core.context_processors.debug',
+    'django.core.context_processors.i18n',
+    'django.core.context_processors.tz',
+    'django.core.context_processors.media',
+    'django.core.context_processors.static',
+    'django.core.context_processors.request',
+    'django.contrib.messages.context_processors.messages',
+    'openquakeplatform.utils.oq_context_processor',
+)
 
 # Application definition
 INSTALLED_APPS = (
@@ -72,7 +87,6 @@ STANDALONE_APPS = (
     'openquakeplatform_ipt',
     'openquakeplatform_taxtweb',
 )
-
 
 MIDDLEWARE_CLASSES = (
     # 'django.contrib.sessions.middleware.SessionMiddleware',
@@ -103,7 +117,6 @@ TIME_ZONE = 'UTC'
 USE_I18N = True
 USE_L10N = True
 USE_TZ = True
-
 
 # Static files (CSS, JavaScript, Images)
 STATIC_URL = '/static/'

--- a/openquakeplatform_server/settings.py
+++ b/openquakeplatform_server/settings.py
@@ -32,6 +32,7 @@ TEMPLATES = [
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
+                'django.core.context_processors.request',
                 # 'django.contrib.auth.context_processors.auth',
                 'django.template.context_processors.debug',
                 'django.template.context_processors.i18n',
@@ -39,7 +40,7 @@ TEMPLATES = [
                 'django.template.context_processors.static',
                 'django.template.context_processors.tz',
                 # 'django.contrib.messages.context_processors.messages',
-                # 'openquakeplatform.utils.oq_context_processor',
+                'openquakeplatform.utils.oq_context_processor',
             ],
         },
     },

--- a/openquakeplatform_server/settings.py
+++ b/openquakeplatform_server/settings.py
@@ -15,28 +15,43 @@ STANDALONE = True
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
-
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.6/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = 'klugdi+_!+e$dwvl!wy0uxi)gedje*l=*4@wv+%h#%0=hup%0f'
 
+ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
+
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-TEMPLATE_DEBUG = True
-
-ALLOWED_HOSTS = ["localhost", "127.0.0.1"]
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                # 'django.contrib.auth.context_processors.auth',
+                'django.template.context_processors.debug',
+                'django.template.context_processors.i18n',
+                'django.template.context_processors.media',
+                'django.template.context_processors.static',
+                'django.template.context_processors.tz',
+                # 'django.contrib.messages.context_processors.messages',
+                # 'openquakeplatform.utils.oq_context_processor',
+            ],
+        },
+    },
+]
 
 # Application definition
-
 INSTALLED_APPS = (
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
+    # 'django.contrib.admin',
+    # 'django.contrib.auth',
+    # 'django.contrib.contenttypes',
+    # 'django.contrib.sessions',
+    # 'django.contrib.messages',
     'django.contrib.staticfiles',
 
     'openquakeplatform',
@@ -57,66 +72,40 @@ STANDALONE_APPS = (
     'openquakeplatform_taxtweb',
 )
 
-TEMPLATE_CONTEXT_PROCESSORS = (
-    'django.contrib.auth.context_processors.auth',
-    'django.core.context_processors.debug',
-    'django.core.context_processors.i18n',
-    "django.core.context_processors.tz",
-    'django.core.context_processors.media',
-    "django.core.context_processors.static",
-    'django.core.context_processors.request',
-    'django.contrib.messages.context_processors.messages',
-)
 
 MIDDLEWARE_CLASSES = (
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    # 'django.contrib.sessions.middleware.SessionMiddleware',
+    # 'django.middleware.common.CommonMiddleware',
+    # 'django.middleware.csrf.CsrfViewMiddleware',
+    # 'django.contrib.auth.middleware.AuthenticationMiddleware',
+    # 'django.contrib.messages.middleware.MessageMiddleware',
+    # 'django.middleware.clickjacking.XFrameOptionsMiddleware',
 )
 
 ROOT_URLCONF = 'openquakeplatform_server.urls'
 
 WSGI_APPLICATION = 'openquakeplatform_server.wsgi.application'
 
-
-# Database
-# https://docs.djangoproject.com/en/1.6/ref/settings/#databases
+FILE_PATH_FIELD_DIRECTORY = os.path.join(os.path.expanduser('~'), 'oqdata')
 
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+        'NAME': os.path.join(FILE_PATH_FIELD_DIRECTORY,
+                             'platform-standalone.sqlite3'),
     }
 }
 
 # Internationalization
-# https://docs.djangoproject.com/en/1.6/topics/i18n/
-
 LANGUAGE_CODE = 'en-us'
-
 TIME_ZONE = 'UTC'
-
 USE_I18N = True
-
 USE_L10N = True
-
 USE_TZ = True
 
 
 # Static files (CSS, JavaScript, Images)
-# https://docs.djangoproject.com/en/1.6/howto/static-files/
-
 STATIC_URL = '/static/'
-
-# the '/' suffix is MANDATORY
-FILE_PATH_FIELD_DIRECTORY = os.path.join(os.path.expanduser('~'), 'oqdata')
-
-TEMPLATE_CONTEXT_PROCESSORS += (
-    'openquakeplatform.utils.oq_context_processor',
-)
 
 try:
     from local_settings import *

--- a/openquakeplatform_server/urls.py
+++ b/openquakeplatform_server/urls.py
@@ -1,8 +1,9 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 from settings import STANDALONE_APPS
 from django.contrib import admin
 from django.views.generic import TemplateView
+from django.views.i18n import javascript_catalog
 
 
 js_info_dict = {
@@ -12,23 +13,22 @@ js_info_dict = {
 
 admin.autodiscover()
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^lang\.js$',
         TemplateView.as_view(template_name='lang.js',
                              content_type='text/javascript'),
         name='lang'),
-    url(r'^jsi18n/$', 'django.views.i18n.javascript_catalog',
-        js_info_dict, name='jscat'),
-    (r'^i18n/', include('django.conf.urls.i18n')),
+    url(r'^jsi18n/$', javascript_catalog, js_info_dict,
+        name='javascript-catalog'),
+    url(r'^i18n/', include('django.conf.urls.i18n')),
 
-    url(r'^admin/', include(admin.site.urls)),
-)
+    # Uncomment the following line to enable admin
+    # url(r'^admin/', include(admin.site.urls)),
+]
 
 for app in STANDALONE_APPS:
     # STANDALONE_APPS format is openquakeplatform_appname
     # app_name is made by the token after '_' and used for suburl and namespace
     app_name = app.split('_')[1]
-    urlpatterns += patterns('',
-                            url(r'^%s/' % app_name, include('%s.urls' % app,
-                                namespace='%s' % app_name)))
+    urlpatterns.append(url(r'^%s/' % app_name, include('%s.urls' % app,
+                       namespace='%s' % app_name)))

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     author_email='devops@openquake.org',
     scripts=['openquakeplatform_server/bin/openquakeplatform_srv.py'],
     install_requires = [
-        'django >=1.6, <1.11',
+        'django >=1.5, <1.11',
         'openquake.engine',
         'openquake.hazardlib',
     ]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import os
-from setuptools import find_packages, setup
+from setuptools import setup
 
 with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as readme:
     README = readme.read()
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 setup(
     name='oq-platform-standalone',
     version='1.0',
-#    packages=find_packages(),
+    # packages=find_packages(),
     packages=["openquakeplatform", "openquakeplatform_server"],
     include_package_data=True,
     license='BSD License',  # example license
@@ -20,20 +20,18 @@ setup(
     author='GEM Foundation',
     author_email='devops@openquake.org',
     scripts=['openquakeplatform_server/bin/openquakeplatform_srv.py'],
-    install_requires = [
+    install_requires=[
         'django >=1.5, <1.11',
         'openquake.engine',
         'openquake.hazardlib',
-    ]
+    ],
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',
-        'Framework :: Django :: 1.6',
         'Intended Audience :: Scientists',
-        'License :: OSI Approved :: AGPL3',  # example license
+        'License :: OSI Approved :: AGPL3',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        # Replace these appropriately if you are stuck on Python 2.
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Topic :: Internet :: WWW/HTTP',

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,11 @@ setup(
     author='GEM Foundation',
     author_email='devops@openquake.org',
     scripts=['openquakeplatform_server/bin/openquakeplatform_srv.py'],
+    install_requires = [
+        'django >=1.6, <1.11',
+        'openquake.engine',
+        'openquake.hazardlib',
+    ]
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Django',

--- a/verifier.sh
+++ b/verifier.sh
@@ -410,14 +410,8 @@ source platform-env/bin/activate
 if dpkg -l python-simplejson 2>/dev/null | tail -n +6 | grep -q '^ii '; then
     pip install simplejson==2.0.9
 fi
-cd -
-cd oq-platform-ipt
-sudo python setup.py install
-cd -
-cd oq-platform-taxtweb
-sudo python setup.py install
-cd -
-cd ~/$GEM_GIT_PACKAGE
+pip install -e ../oq-platform-ipt/
+pip install -e ../oq-platform-taxtweb/
 
 pip install -e .
 


### PR DESCRIPTION
https://ci.openquake.org/job/zdevel_oq-platform-standalone/63/
https://platform-staging.openquake.org/ipt/ is running on platform master and ipt+taxtweb from `compat`

These changes have been also made:

- `auth` and `admin` infrastructures have been disabled but code has been left in place for future reference
- `db` has been moved to `~/oqdata/platform-standalone.sqlite3`. It isn't used right now, but if we'll need it it should be kept separated from the app
- A minimal set of dependencies have been added to `setup.py`

Companions:
- https://github.com/gem/oq-platform-taxtweb/issues/14
- https://github.com/gem/oq-platform-ipt/issues/24