### PR TITLE
Remove Python 2 testing

### DIFF
--- a/verifier.sh
+++ b/verifier.sh
@@ -435,7 +435,6 @@ if kill -0 \$server >/dev/null 2>&1; then
     kill -KILL \$server
 fi
 deactivate
-py_ver=\$(( py_ver + 1 ))
 "
 
     echo "_devtest_innervm_run: exit"

--- a/verifier.sh
+++ b/verifier.sh
@@ -398,8 +398,8 @@ wget \"http://ftp.openquake.org/mirror/mozilla/geckodriver-v\${GEM_GECKODRIVER_V
 tar zxvf \"geckodriver-v\${GEM_GECKODRIVER_VERSION}-linux64.tar.gz\"
 sudo cp geckodriver /usr/local/bin
 
-py_ver=2
-for pyto in \$(which python2) \$(which python3); do
+py_ver=3
+for pyto in \$(which python3); do
     cd \$HOME
     virtualenv -p \${pyto} env_\${py_ver}
     source env_\${py_ver}/bin/activate


### PR DESCRIPTION
We do not use Python 2 anymore in our installers / packages, so testing it is useless. `oq-engine` is also currently broken under Python2.

https://ci.openquake.org/job/zdevel_oq-platform-standalone/221/