### PR TITLE
Django-cors-headers requirement

### DIFF
--- a/verifier.sh
+++ b/verifier.sh
@@ -485,7 +485,7 @@ fi
 oq webui start -s &> runserver.log &
 server=\$!
 echo \"\$server\" > /tmp/server.pid
-sleep 4000000
+# sleep 4000000
 
 # FIXME Grace time for openquake.server to be started asynchronously
 # should be replaced by a timeboxed loop with an availability check

--- a/verifier.sh
+++ b/verifier.sh
@@ -476,7 +476,6 @@ if [ -z \$GEM_TOOLS_ONLY ]; then
     sudo chown -R ubuntu /var/www/webui
     cd oq-engine/openquake/server
     cp local_settings.py.tools local_settings.py
-    pip install django-cors-headers
     pip install django-cookie-consent
     python manage.py migrate
     python manage.py loaddata ../../../oq-platform-standalone/openquakeplatform/fixtures/0001_cookie_consent.json

--- a/verifier.sh
+++ b/verifier.sh
@@ -485,6 +485,7 @@ fi
 oq webui start -s &> runserver.log &
 server=\$!
 echo \"\$server\" > /tmp/server.pid
+sleep 4000000
 
 # FIXME Grace time for openquake.server to be started asynchronously
 # should be replaced by a timeboxed loop with an availability check


### PR DESCRIPTION
Deleted pip install django-cors-headers from verifier script because is inside the oq-engine requirements

The test are running here: 